### PR TITLE
chore: agregar plantillas para GitHub

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contribución – Mueblería Hermanos Jota
+
+## Flujo de trabajo
+1. Tomá una tarea del Project (columna Ready), asignate y movela a **In progress**.
+2. Creá una rama desde `main` (ver convención abajo).
+3. Hacé commits pequeños y claros.
+4. Abrí un PR a `main` cuando termines. **Se requieren 2 aprobaciones.**
+5. Al mergear, la tarjeta pasa a **Done**. Eliminá la rama.
+
+## Convención de ramas
+- `feat/<breve-descripcion>` – nueva funcionalidad  
+- `fix/<breve-descripcion>` – corrección  
+- `chore/<breve-descripcion>` – mantenimiento/configuración  
+- `docs/<breve-descripcion>` – documentación
+
+**Ejemplos**
+- `feat/home-hero`
+- `feat/productos-grid`
+- `fix/navbar-responsive`
+- `chore/add-gitignore`
+- `docs/readme-raiz`
+
+## Convención de commits (Conventional Commits)
+`tipo(scope): resumen`
+
+**Tipos**: `feat`, `fix`, `chore`, `docs`, `refactor`, `style` (solo formato), `test`
+
+**Ejemplos**
+- `feat(home): sección de destacados`
+- `fix(navbar): corrige overflow en mobile`
+- `chore: agrega .gitkeep y .gitignore`
+- `docs: actualiza README`
+
+## Pull Requests
+- **Título**: mismo estilo que el commit principal.  
+- **Descripción**: qué cambia y por qué.  
+- **Checklist** del template completo.  
+- Referenciá la issue: `Closes #12`.  
+- **No** se hace push directo a `main` (rama protegida).
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Resumen
+¿Qué cambia este PR? ¿Por qué?
+
+## Cómo probarlo
+1. Pasos claros para ver el cambio
+2. Página/archivo afectado
+
+## Checklist
+- [ ] Cumple con la issue: Closes #<número>
+- [ ] No hay errores en consola
+- [ ] HTML semántico (etiquetas correctas)
+- [ ] Accesibilidad básica (alt/label/contraste)
+- [ ] Responsive 360 / 768 / 1280
+- [ ] Código formateado
+
+## Capturas (opcional)
+Adjuntar imágenes o GIFs si aplica


### PR DESCRIPTION
## Resumen
Se agrega la carpeta `.github/` con:
- `pull_request_template.md`
- `CONTRIBUTING.md`
- 
Objetivo: estandarizar el flujo de trabajo (ramas, commits y revisiones) y acelerar la creación de PRs e issues.

## Cómo probarlo
1) Crear un **nuevo Pull Request** → debe aparecer el template automáticamente.
2) Ir a **Issues → New issue** → deben verse las opciones “Feature request” y “Bug report”.
3) Abrir el archivo `CONTRIBUTING.md` y verificar reglas de ramas/commits/PRs.
4) (Si subiste `CODEOWNERS`) Abrir un PR de prueba y confirmar que se asignan reviewers.

## Checklist
- [x] Archivos en `.github/` visibles en el repo
- [x] Templates se aplican al crear PR/Issue
- [x] Reglas de contribución claras (ramas, commits, PRs)
- [x] Sin cambios en código de producción

## Notas
- Este PR no modifica HTML/CSS/JS del sitio, solo configuración del repo.
