### PR TITLE
fix/estilos-tarjetas-productos

### DIFF
--- a/frontend/assets/css/styles.css
+++ b/frontend/assets/css/styles.css
@@ -361,6 +361,7 @@ footer ul {
 
 /* Cada producto */
 article {
+  width: 20rem;
   background: #fff;
   border-radius: 12px;
   box-shadow: 0 4px 12px rgba(0,0,0,0.08);
@@ -381,8 +382,7 @@ article:hover {
 }
 
 article img {
-  width: 100%;
-  height: 220px;
+  width: 100%;;
   object-fit: cover;
 }
 


### PR DESCRIPTION
## Resumen
Se ajustan los estilos de las tarjetas de productos del catálogo para que las mismas estén alineadas y sean del mismo alto/ancho.

## Cómo probarlo
1. Abrir productos.html
2. Verificar que las tarjetas estén alineadas.
3. Verificar que las tarjetas sean del mismo alto y del mismo ancho.

## Checklist
- [x] Cumple con la issue: Closes #47 
- [x] Código formateado
