### PR TITLE
chore(logger + server): corregido nombre de la función de logger a log

### DIFF
--- a/backend/middleware/logger.js
+++ b/backend/middleware/logger.js
@@ -1,8 +1,8 @@
-function logger(req, res, next) {
+function log(req, res, next) {
   console.log(`Petición Recibida: ${req.method} en la ruta ${req.originalUrl}`);
   next();
 }
 
 module.exports = {
-  logger,
+  log,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,14 +1,14 @@
 const express = require("express");
 
 // Middleware imports
-const logger = require("./middleware/logger.js").logger;
+const logger = require("./middleware/logger.js");
 
 const app = express();
 const PORT = 3001;
 
 // Global middlewares
 app.use(express.json());
-app.use(logger);
+app.use(logger.log);
 
 // Routes
 


### PR DESCRIPTION
## Resumen
Se cambia el nombre de la función middleware en logger.js de logger a log para que tenga un nombre apropiado.

## Cómo probarlo
1. Abrir logger.js en middleware/logger.js.
2. Verificar que la función se llame log y que se esté exportando correctamente.
3. Abrir server.js y verificar que se esté importando la función log y usando correctamente.
4. Correr el servidor con node server.js y entrar a algunas rutas para verificar que se esté mostrando por consola los logs.

## Checklist
- [x] Cumple con la issue: Closes #94 
- [x] No hay errores en consola
- [x] Código formateado
