### PR TITLE
feat: se crea endpoint para monitoreo de server

### DIFF
--- a/backend/middleware/request.js
+++ b/backend/middleware/request.js
@@ -1,0 +1,9 @@
+let count = 0;
+
+const requestCounter = (req, res, next) => {
+    count++;
+    req.app.set('requestCount', count);
+    next();
+}
+
+module.exports = requestCounter;

--- a/backend/routes/status.js
+++ b/backend/routes/status.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const router = express.Router();
+
+/**
+ * @swagger
+ * /api/status:
+ *   get:
+ *     summary: Estado del servidor
+ *     tags: [Status]
+ *     responses:
+ *       200:
+ *         description: Uptime del servidor, cantidad de requests y timestamp actual
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 uptime:
+ *                   type: number
+ *                 requests:
+ *                   type: integer
+ *                 timestamp:
+ *                   type: string
+ *                   format: date-time
+ */
+
+router.get('/', (req, res) => {
+    const uptime = process.uptime();
+    const requests = req.app.get('requestCount') ?? 0;
+    const timestamp = new Date().toISOString();
+    res.json({ uptime, requests, timestamp })
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,6 +3,7 @@ require("dotenv").config();
 
 // Importación de middlewares y utilidades
 const logger = require("./middleware/logger.js");
+const requestCounter = require("./middleware/request.js");
 
 // Importación de Swagger para documentación interactiva
 const swaggerUi = require('swagger-ui-express');
@@ -15,6 +16,7 @@ const PORT = process.env.PORT || 3001;
 // Middlewares globales
 app.use(express.json());      // Permite recibir JSON en las peticiones
 app.use(logger.log);          // Middleware personalizado para logs
+app.use(requestCounter);
 
 // Documentación Swagger disponible en /api/docs
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
@@ -26,6 +28,9 @@ app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
  */
 const productsRouter = require('./routes/products');
 app.use('/api/productos', productsRouter);
+
+const statusRouter = require('./routes/status.js');
+app.use('/api/status', statusRouter);
 
 // Levanta el servidor en el puerto especificado
 app.listen(PORT, () => {

--- a/backend/swagger.js
+++ b/backend/swagger.js
@@ -15,7 +15,7 @@ const options = {
       },
     ],
   },
-  apis: ['./routes/products.js'],
+  apis: ['./routes/products.js', './routes/status.js'],
 };
 
 const swaggerSpec = swaggerJSDoc(options);


### PR DESCRIPTION
## Resumen
Se crea endpoint /api/status para monitoreo del servidor. 

## Cómo probarlo
1. Correr el servidor con `npm run dev`
2. Hacer una petición GET al endpoint /api/status
3. Verificar que devuelva un json con información basica (uptime, requests y timestamp)

## Checklist
- [x] Cumple con la issue: Closes #86 
- [x] No hay errores en consola
- [x] Código formateado
