### PR TITLE
Chore/repo cleanup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
-  }
-}


### PR DESCRIPTION
## Resumen
Se elimina la carpeta `.vscode` de la raiz del proyecto

## Cómo probarlo
1. Abrir el repositorio en la rama `chore/repo-cleanup`
2. Validar que la carpeta `.vscode` se borro

## Checklist
- [ ] Carpeta `.vscode` eliminada