### PR TITLE
fix/catalog-reload

### DIFF
--- a/client/src/pages/ProductForm.jsx
+++ b/client/src/pages/ProductForm.jsx
@@ -324,6 +324,7 @@ function ProductForm() {
         });
 
         setTimeout(() => {
+          refetch();
           navigate(`/productos`);
         }, 2000);
       } else {

--- a/client/src/pages/ProductForm.jsx
+++ b/client/src/pages/ProductForm.jsx
@@ -5,12 +5,15 @@ import {
   updateProduct,
 } from "../services/productService";
 import { useNavigate, useParams } from "react-router-dom";
+import { useProductsContext } from "../context/ProductsContext";
 
 function ProductForm() {
   const navigate = useNavigate();
 
   const { id } = useParams();
   const isEditMode = Boolean(id);
+
+  const { refetch } = useProductsContext();
 
   const [formData, setFormData] = useState({
     nombre: "",
@@ -331,6 +334,7 @@ function ProductForm() {
         });
 
         setTimeout(() => {
+          refetch();
           navigate("/productos");
         }, 2000);
       }


### PR DESCRIPTION
## Resumen
Esta PR arregla el bug de que no se refrescaba correctamente el catálogo de productos tras añadir un producto nuevo o modificar un producto existente.

## Cómo probarlo
1. Levantar back y front.
2. Añadir un nuevo producto.
3. Verificar que tras redirigirse al catálogo el nuevo producto se muestre.
4. Probar lo mismo modificando un producto existente.

## Checklist
- [x] No hay errores en consola
- [x] Código formateado
